### PR TITLE
Fixed typo which was preventing geocoder from working on mock data

### DIFF
--- a/iBurn/src/main/java/com/gaiagps/iburn/location/LocationProvider.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/location/LocationProvider.kt
@@ -78,7 +78,7 @@ object LocationProvider {
         init(context)
         return if (BuildConfig.MOCK) {
             flow {
-                lastMockLocation
+                emit(lastMockLocation)
             }
         } else {
             if (!PermissionManager.hasLocationPermissions(context)) {


### PR DESCRIPTION
The mock location was missing an emit()