### PR TITLE
only copy mbtiles once per version

### DIFF
--- a/iBurn/src/main/java/com/gaiagps/iburn/MapboxMapFragment.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/MapboxMapFragment.kt
@@ -56,6 +56,8 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.collections.set
 
+// Track MBTiles versions to avoid unnecessary copies from assets
+const val MBTILES_VERSION = 1L
 
 class MapboxMapFragment : Fragment() {
 
@@ -339,6 +341,10 @@ class MapboxMapFragment : Fragment() {
     private fun copyAssets(): String {
         val tilesInput = requireContext().assets.open("map/map.mbtiles")
         val tilesOutput = File(requireContext().getExternalFilesDir(null), "map.mbtiles")
+        val prefs = PrefsHelper(requireContext())
+        if (tilesOutput.exists() && prefs.copiedMbtilesVersion == MBTILES_VERSION) {
+            return tilesOutput.path
+        }
         val tilesOutputStream = tilesOutput.outputStream()
         val buffer = ByteArray(1024)
         var read: Int
@@ -348,6 +354,7 @@ class MapboxMapFragment : Fragment() {
         tilesInput.close()
         tilesOutputStream.flush()
         tilesOutputStream.close()
+        prefs.copiedMbtilesVersion = MBTILES_VERSION
         return tilesOutput.path
     }
 

--- a/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
@@ -16,6 +16,8 @@ public class PrefsHelper {
     private static final String POPULATED_DB_VERSION = "db_populated_ver";  // long
     private static final String SCHEDULED_UPDATE = "sched_update";          // boolean
 
+
+    private static final String COPIED_MBTILES_VERSION = "copied_tiles";    // long
     private static final String DEFAULT_RESOURCE_VERSION = "resver";        // long
     private static final String RESOURCE_VERSION_PREFIX = "res-";           // long
 
@@ -57,6 +59,14 @@ public class PrefsHelper {
 
     public void setDidShowWelcome(boolean didShow) {
         editor.putBoolean(getAnnualKey(SHOWED_WELCOME), didShow).commit();
+    }
+
+    public void setCopiedMbtilesVersion(long version) {
+        editor.putLong(COPIED_MBTILES_VERSION, version).commit();
+    }
+
+    public long getCopiedMbtilesVersion() {
+        return sharedPrefs.getLong(COPIED_MBTILES_VERSION, 0);
     }
 
     public void setDatabaseVersion(long version) {


### PR DESCRIPTION
Previously the mbtiles got copied from the application package to app file storage every time the map was shown. 

I think this could be responsible for our current [top crash](https://console.firebase.google.com/project/iburn-app/crashlytics/app/android:com.iburnapp.iburn3/issues/43537052c5a329626c5019e8d4037008?time=last-seven-days&types=crash&sessionEventKey=64DBB7AF03B9000121CDDC345F9E815E_1846050219759390589), well top if you don't count the Now (Hang my app) button.

I think that if multiple instances of the map were visible (like when multiple PlayaItemViewActivity's were in the stack) the destination file was locked, failing the copy and throwing an exception. 

This will also further iBurn's energy conservation initiatives 