### PR TITLE
Fix incorrect bundled event times

### DIFF
--- a/iBurn/src/main/java/com/gaiagps/iburn/DateUtil.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/DateUtil.java
@@ -18,6 +18,10 @@ public class DateUtil {
 
     private static SimpleDateFormat TIME_FORMATTER = new SimpleDateFormat("h:mm a", Locale.US);
 
+    static {
+        TIME_FORMATTER.setTimeZone(PLAYA_TIME_ZONE);
+    }
+
     /**
      * Get a human description of an event's state
      * (e.g: Starts in XX, Ends in XX)

--- a/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
@@ -17,6 +17,8 @@ public class PrefsHelper {
     private static final String SCHEDULED_UPDATE = "sched_update";          // boolean
 
 
+    // Initial 2023 bundled db had pretty event times formatted in EDT
+    private static final String FIXED_EVENTS_TABLE = "23-event-time-fix";   // boolean
     private static final String COPIED_MBTILES_VERSION = "copied_tiles";    // long
     private static final String DEFAULT_RESOURCE_VERSION = "resver";        // long
     private static final String RESOURCE_VERSION_PREFIX = "res-";           // long
@@ -40,6 +42,14 @@ public class PrefsHelper {
      */
     private String getAnnualKey(String baseKey) {
         return String.format("%s_%s", baseKey, context.getString(R.string.current_year));
+    }
+
+    public boolean fixedEventTimes() {
+        return sharedPrefs.getBoolean(FIXED_EVENTS_TABLE, false);
+    }
+
+    public void setFixedEventTimes(boolean didEnter) {
+        editor.putBoolean(FIXED_EVENTS_TABLE, didEnter).commit();
     }
 
     /**

--- a/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
@@ -48,8 +48,8 @@ public class PrefsHelper {
         return sharedPrefs.getBoolean(FIXED_EVENTS_TABLE, false);
     }
 
-    public void setFixedEventTimes(boolean didEnter) {
-        editor.putBoolean(FIXED_EVENTS_TABLE, didEnter).commit();
+    public void setFixedEventTimes(boolean didFix) {
+        editor.putBoolean(FIXED_EVENTS_TABLE, didFix).commit();
     }
 
     /**

--- a/iBurn/src/main/java/com/gaiagps/iburn/api/EventUpdater.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/api/EventUpdater.java
@@ -1,0 +1,39 @@
+package com.gaiagps.iburn.api;
+
+import android.content.Context;
+
+import com.gaiagps.iburn.api.response.DataManifest;
+import com.gaiagps.iburn.api.response.ResourceManifest;
+import com.gaiagps.iburn.database.DataProvider;
+
+import java.util.Date;
+
+/**
+ * The initial 2023 bundled db had 'pretty' time columns in EDT instead of PDT.
+ * Fix this colossal bug by re-creating event table from JSON for affected installs.
+ */
+public class EventUpdater extends MockIBurnApi {
+    public EventUpdater(Context context) {
+        super(context);
+    }
+
+    public static boolean needsFix(Context context) {
+        // As a test, use Black Rock City 5k event, which should have a formatted start time of
+        // "Thu 8/31 9:30 AM", but was recorded as "Thu 8/31 9:30 AM" in the initial borked DB
+        return DataProvider.Companion.getInstance(context)
+                .flatMap(dataProvider -> dataProvider.observeEventByPlayaId("3y6Fs46vcvfYCVdmR8kU").toObservable())
+                .map(event -> event.startTimePretty.equals("Thu 8/31 12:30 PM"))
+                .blockingFirst();
+
+    }
+
+    @Override
+    protected DataManifest buildManifest() {
+        // Only indicate new event data is available
+        ResourceManifest event = new ResourceManifest("event.json", new Date());
+        ResourceManifest art = new ResourceManifest("art.json", new Date(0));
+        ResourceManifest camp = new ResourceManifest("camp.json", new Date(0));
+        return new DataManifest(art, camp, event);
+    }
+}
+

--- a/iBurn/src/main/java/com/gaiagps/iburn/api/EventUpdater.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/api/EventUpdater.java
@@ -20,7 +20,7 @@ public class EventUpdater extends MockIBurnApi {
 
     public static boolean needsFix(Context context) {
         // As a test, use Black Rock City 5k event, which should have a formatted start time of
-        // "Thu 8/31 9:30 AM", but was recorded as "Thu 8/31 9:30 AM" in the initial borked DB
+        // "Thu 8/31 9:30 AM", but was recorded as "Thu 8/31 12:30 PM" in the initial borked DB
         return DataProvider.Companion.getInstance(context)
                 .flatMap(dataProvider -> dataProvider.observeEventByPlayaId("3y6Fs46vcvfYCVdmR8kU").toObservable())
                 .timeout(1, TimeUnit.SECONDS)

--- a/iBurn/src/main/java/com/gaiagps/iburn/api/EventUpdater.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/api/EventUpdater.java
@@ -7,6 +7,7 @@ import com.gaiagps.iburn.api.response.ResourceManifest;
 import com.gaiagps.iburn.database.DataProvider;
 
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The initial 2023 bundled db had 'pretty' time columns in EDT instead of PDT.
@@ -22,7 +23,9 @@ public class EventUpdater extends MockIBurnApi {
         // "Thu 8/31 9:30 AM", but was recorded as "Thu 8/31 9:30 AM" in the initial borked DB
         return DataProvider.Companion.getInstance(context)
                 .flatMap(dataProvider -> dataProvider.observeEventByPlayaId("3y6Fs46vcvfYCVdmR8kU").toObservable())
+                .timeout(1, TimeUnit.SECONDS)
                 .map(event -> event.startTimePretty.equals("Thu 8/31 12:30 PM"))
+                .onErrorReturnItem(false)
                 .blockingFirst();
 
     }

--- a/iBurn/src/main/java/com/gaiagps/iburn/api/IBurnService.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/api/IBurnService.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.core.util.Pair;
 import android.text.TextUtils;
 
+import com.gaiagps.iburn.DateUtil;
 import com.gaiagps.iburn.PrefsHelper;
 import com.gaiagps.iburn.adapters.AdapterUtils;
 import com.gaiagps.iburn.api.response.Art;
@@ -323,8 +324,10 @@ public class IBurnService {
         //final SimpleDateFormat mahineDateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ssX", Locale.US);
         // Date format for human-readable specific-time
         final SimpleDateFormat timeDayFormatter = new SimpleDateFormat("EE M/d h:mm a", Locale.US);
+        timeDayFormatter.setTimeZone(DateUtil.PLAYA_TIME_ZONE);
         // Date format for human-readable all-day
         final SimpleDateFormat dayFormatter = new SimpleDateFormat("EE M/d", Locale.US);
+        timeDayFormatter.setTimeZone(DateUtil.PLAYA_TIME_ZONE);
 
         final String tableName = com.gaiagps.iburn.database.Event.TABLE_NAME;
         return updateTable(provider, service.getEvents(), tableName, new EventLifeboat(), (item, values, database) -> {

--- a/iBurn/src/main/java/com/gaiagps/iburn/api/IBurnService.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/api/IBurnService.java
@@ -327,7 +327,7 @@ public class IBurnService {
         timeDayFormatter.setTimeZone(DateUtil.PLAYA_TIME_ZONE);
         // Date format for human-readable all-day
         final SimpleDateFormat dayFormatter = new SimpleDateFormat("EE M/d", Locale.US);
-        timeDayFormatter.setTimeZone(DateUtil.PLAYA_TIME_ZONE);
+        dayFormatter.setTimeZone(DateUtil.PLAYA_TIME_ZONE);
 
         final String tableName = com.gaiagps.iburn.database.Event.TABLE_NAME;
         return updateTable(provider, service.getEvents(), tableName, new EventLifeboat(), (item, values, database) -> {

--- a/iBurn/src/main/java/com/gaiagps/iburn/api/MockIBurnApi.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/api/MockIBurnApi.java
@@ -42,6 +42,10 @@ public class MockIBurnApi implements IBurnApi {
                 .registerTypeAdapter(Date.class, new PlayaDateTypeAdapter())
                 .create();
 
+        manifest = buildManifest();
+    }
+
+    protected DataManifest buildManifest() {
         // Don't trigger an update
         //ResourceManifest map = new ResourceManifest("map.mbtiles.jar", new Date(0));
 
@@ -49,8 +53,7 @@ public class MockIBurnApi implements IBurnApi {
         ResourceManifest art = new ResourceManifest("art.json", new Date());
         ResourceManifest camp = new ResourceManifest("camp.json", new Date());
         ResourceManifest event = new ResourceManifest("event.json", new Date());
-
-        manifest = new DataManifest(art, camp, event);
+        return new DataManifest(art, camp, event);
     }
 
     @Override

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
@@ -128,6 +128,10 @@ class DataProvider private constructor(private val context: Context, private val
         //        if (result != null) result.close();
     }
 
+    fun observeEventByPlayaId(id: String): Flowable<Event> {
+        return db.eventDao().getByPlayaId(id)
+    }
+
     fun observeEventsOnDayOfTypes(day: String,
                                   types: ArrayList<String>?,
                                   includeExpired: Boolean,

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
@@ -4,17 +4,18 @@ import android.content.ContentValues
 import android.content.Context
 import com.gaiagps.iburn.AudioTourManager
 import com.gaiagps.iburn.CurrentDateProvider
+import com.gaiagps.iburn.DateUtil
 import com.gaiagps.iburn.PrefsHelper
 import com.gaiagps.iburn.api.typeadapter.PlayaDateTypeAdapter
 import com.gaiagps.iburn.view.Utils
-import com.gaiagps.iburn.DateUtil
 import com.mapbox.mapboxsdk.geometry.VisibleRegion
 import io.reactivex.Flowable
 import io.reactivex.Observable
+import io.reactivex.Single
 import io.reactivex.rxkotlin.Flowables
 import io.reactivex.schedulers.Schedulers
 import timber.log.Timber
-import java.util.*
+import java.util.Date
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -128,7 +129,7 @@ class DataProvider private constructor(private val context: Context, private val
         //        if (result != null) result.close();
     }
 
-    fun observeEventByPlayaId(id: String): Flowable<Event> {
+    fun observeEventByPlayaId(id: String): Single<Event> {
         return db.eventDao().getByPlayaId(id)
     }
 

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/EventDao.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/EventDao.java
@@ -31,7 +31,8 @@ import static com.gaiagps.iburn.database.PlayaItem.PLAYA_ID;
 public interface EventDao {
     @Query("SELECT * FROM " + TABLE_NAME)
     Flowable<List<Event>> getAll();
-
+    @Query("SELECT * FROM " + TABLE_NAME + " WHERE " + PLAYA_ID + " = :id")
+    Flowable<Event> getByPlayaId(String id);
     @Query("SELECT * FROM " + TABLE_NAME + " WHERE " + FAVORITE + " = 1 ORDER BY " + START_TIME)
     Flowable<List<Event>> getFavorites();
 

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/EventDao.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/EventDao.java
@@ -1,14 +1,5 @@
 package com.gaiagps.iburn.database;
 
-import androidx.room.Dao;
-import androidx.room.Insert;
-import androidx.room.Query;
-import androidx.room.Update;
-
-import java.util.List;
-
-import io.reactivex.Flowable;
-
 import static com.gaiagps.iburn.database.Event.ALL_DAY;
 import static com.gaiagps.iburn.database.Event.CAMP_PLAYA_ID;
 import static com.gaiagps.iburn.database.Event.END_TIME;
@@ -23,6 +14,16 @@ import static com.gaiagps.iburn.database.PlayaItem.LONGITUDE;
 import static com.gaiagps.iburn.database.PlayaItem.NAME;
 import static com.gaiagps.iburn.database.PlayaItem.PLAYA_ID;
 
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.Query;
+import androidx.room.Update;
+
+import java.util.List;
+
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+
 /**
  * Created by dbro on 6/8/17.
  */
@@ -32,7 +33,7 @@ public interface EventDao {
     @Query("SELECT * FROM " + TABLE_NAME)
     Flowable<List<Event>> getAll();
     @Query("SELECT * FROM " + TABLE_NAME + " WHERE " + PLAYA_ID + " = :id")
-    Flowable<Event> getByPlayaId(String id);
+    Single<Event> getByPlayaId(String id);
     @Query("SELECT * FROM " + TABLE_NAME + " WHERE " + FAVORITE + " = 1 ORDER BY " + START_TIME)
     Flowable<List<Event>> getFavorites();
 

--- a/iBurn/src/main/java/com/gaiagps/iburn/view/Utils.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/view/Utils.java
@@ -5,6 +5,7 @@ import com.gaiagps.iburn.DateUtil;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 /**
@@ -22,7 +23,7 @@ public class Utils {
 
     public static String convertDateToString(Date datetime){
         TimeZone tz = DateUtil.PLAYA_TIME_ZONE;
-        DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
         formatter.setTimeZone(tz);
         String datetime_string = formatter.format(datetime);
         return datetime_string;


### PR DESCRIPTION
Two parts:

1. Make the human readable date formatters timezone aware
2. Add a mechanism to update the event table with bundled JSON if the human readable start time has the known incorrect value.

I think this is what we need to ensure a fix for existing app installs without losing user data (like favorites, or map POIs).