### PR TITLE
Fix missing event locations... caused by event time fix

### DIFF
--- a/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
@@ -46,11 +46,11 @@ public class PrefsHelper {
         return String.format("%s_%s", baseKey, context.getString(R.string.current_year));
     }
 
-    public boolean fixedEventTimes() {
+    public boolean fixedEventTimesAndLocations() {
         return sharedPrefs.getBoolean(FIXED_EVENTS_TABLE_2, false);
     }
 
-    public void setFixedEventTimes(boolean didFix) {
+    public void setFixedEventTimesAndLocations(boolean didFix) {
         editor.putBoolean(FIXED_EVENTS_TABLE_2, didFix).commit();
     }
 

--- a/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
@@ -19,6 +19,8 @@ public class PrefsHelper {
 
     // Initial 2023 bundled db had pretty event times formatted in EDT
     private static final String FIXED_EVENTS_TABLE = "23-event-time-fix";   // boolean
+    // And then the fix for above issue broke event locations!
+    private static final String FIXED_EVENTS_TABLE_2 = "23-event-time-fix-2";// boolean
     private static final String COPIED_MBTILES_VERSION = "copied_tiles";    // long
     private static final String DEFAULT_RESOURCE_VERSION = "resver";        // long
     private static final String RESOURCE_VERSION_PREFIX = "res-";           // long
@@ -45,11 +47,11 @@ public class PrefsHelper {
     }
 
     public boolean fixedEventTimes() {
-        return sharedPrefs.getBoolean(FIXED_EVENTS_TABLE, false);
+        return sharedPrefs.getBoolean(FIXED_EVENTS_TABLE_2, false);
     }
 
     public void setFixedEventTimes(boolean didFix) {
-        editor.putBoolean(FIXED_EVENTS_TABLE, didFix).commit();
+        editor.putBoolean(FIXED_EVENTS_TABLE_2, didFix).commit();
     }
 
     /**

--- a/iBurn/src/main/java/com/gaiagps/iburn/activity/MainActivity.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/activity/MainActivity.java
@@ -35,7 +35,6 @@ import com.gaiagps.iburn.R;
 import com.gaiagps.iburn.SearchQueryProvider;
 import com.gaiagps.iburn.api.EventUpdater;
 import com.gaiagps.iburn.api.IBurnService;
-import com.gaiagps.iburn.api.MockIBurnApi;
 import com.gaiagps.iburn.database.DataProvider;
 import com.gaiagps.iburn.database.Embargo;
 import com.gaiagps.iburn.databinding.ActivityMainBinding;
@@ -51,7 +50,6 @@ import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 import java.text.SimpleDateFormat;
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.Flowable;
@@ -145,20 +143,20 @@ public class MainActivity extends AppCompatActivity implements SearchQueryProvid
         }
         handleIntent(getIntent());
 
-        if (!prefs.fixedEventTimes()) {
+        if (!prefs.fixedEventTimesAndLocations()) {
             Context context = getApplicationContext();
             if (EventUpdater.needsFix(context)) {
                 IBurnService service = new IBurnService(context, new EventUpdater(context));
                 service.updateData().subscribe(success -> {
                     Timber.d("2023 Event time fix ran with success: %b", success);
                     if (success) {
-                        prefs.setFixedEventTimes(true);
+                        prefs.setFixedEventTimesAndLocations(true);
                     }
                 });
             } else {
                 // Fix not needed
                 Timber.d("2023 Event time fix not needed");
-                prefs.setFixedEventTimes(true);
+                prefs.setFixedEventTimesAndLocations(true);
             }
         }
         // uncomment these to load updated JSON


### PR DESCRIPTION
This will force a full data update from locally bundled JSON if the existing database is affected by either bug (wrong event time timezone or missing location) and so should be less error prone then the single event table update I attempted before. 

In essence this is a "normal" update just from JSON bundled within the app vs. fetched via the API.