### PR TITLE
Fix none-none playa addrs and force another data reload for affected installs`

### DIFF
--- a/iBurn/build.gradle
+++ b/iBurn/build.gradle
@@ -174,7 +174,7 @@ dependencies {
     implementation 'xyz.danoz:recyclerviewfastscroller:0.1.3'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.media:media:1.6.0'
-    implementation 'com.eclipsesource.j2v8:j2v8:4.8.5@aar'
+    implementation 'com.eclipsesource.j2v8:j2v8:6.2.1@aar'
     implementation 'org.maplibre.gl:android-sdk:10.2.0'
     implementation 'org.maplibre.gl:android-plugin-annotation-v9:1.0.0'
 

--- a/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/PrefsHelper.java
@@ -21,6 +21,9 @@ public class PrefsHelper {
     private static final String FIXED_EVENTS_TABLE = "23-event-time-fix";   // boolean
     // And then the fix for above issue broke event locations!
     private static final String FIXED_EVENTS_TABLE_2 = "23-event-time-fix-2";// boolean
+    // And then realized we need to strip "None" from playa address fields due to an issue in
+    // geocoder. This prevented items located within plazas from getting geocoded.
+    private static final String FIXED_EVENTS_TABLE_3 = "23-event-time-fix-3";// boolean
     private static final String COPIED_MBTILES_VERSION = "copied_tiles";    // long
     private static final String DEFAULT_RESOURCE_VERSION = "resver";        // long
     private static final String RESOURCE_VERSION_PREFIX = "res-";           // long
@@ -47,11 +50,11 @@ public class PrefsHelper {
     }
 
     public boolean fixedEventTimesAndLocations() {
-        return sharedPrefs.getBoolean(FIXED_EVENTS_TABLE_2, false);
+        return sharedPrefs.getBoolean(FIXED_EVENTS_TABLE_3, false);
     }
 
     public void setFixedEventTimesAndLocations(boolean didFix) {
-        editor.putBoolean(FIXED_EVENTS_TABLE_2, didFix).commit();
+        editor.putBoolean(FIXED_EVENTS_TABLE_3, didFix).commit();
     }
 
     /**

--- a/iBurn/src/main/java/com/gaiagps/iburn/activity/MainActivity.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/activity/MainActivity.java
@@ -35,6 +35,7 @@ import com.gaiagps.iburn.R;
 import com.gaiagps.iburn.SearchQueryProvider;
 import com.gaiagps.iburn.api.EventUpdater;
 import com.gaiagps.iburn.api.IBurnService;
+import com.gaiagps.iburn.api.MockIBurnApi;
 import com.gaiagps.iburn.database.DataProvider;
 import com.gaiagps.iburn.database.Embargo;
 import com.gaiagps.iburn.databinding.ActivityMainBinding;
@@ -133,8 +134,7 @@ public class MainActivity extends AppCompatActivity implements SearchQueryProvid
             prefs.setDidScheduleUpdate(true);
         }
         // For testing data update live
-        //DataUpdateService.Companion.updateNow(this);
-
+        // DataUpdateService.Companion.updateNow(this);
         if (Embargo.isEmbargoActive(prefs)) {
             Flowable.timer(1, TimeUnit.SECONDS)
                     .observeOn(AndroidSchedulers.mainThread())
@@ -160,10 +160,11 @@ public class MainActivity extends AppCompatActivity implements SearchQueryProvid
                 prefs.setFixedEventTimesAndLocations(true);
             }
         }
-        // uncomment these to load updated JSON
+//        uncomment to load JSON assets immediately for testing
 //        Context context = getApplicationContext();
+//        long startTime = System.currentTimeMillis();
 //        IBurnService service = new IBurnService(context, new MockIBurnApi(context));
-//        service.updateData().subscribe(success -> Timber.d("Update result success: %b", success));
+//        service.updateData().subscribe(success -> Timber.d("Update result success: %b in %d ms", success, System.currentTimeMillis() - startTime));
     }
 
     @Override

--- a/iBurn/src/main/java/com/gaiagps/iburn/api/EventUpdater.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/api/EventUpdater.java
@@ -24,13 +24,29 @@ public class EventUpdater extends MockIBurnApi {
     public static boolean needsFix(Context context) {
         // As a test, use Black Rock City 5k event, which should have a formatted start time of
         // "Thu 8/31 9:30 AM", but was recorded as "Thu 8/31 12:30 PM" in the initial borked DB
-        return DataProvider.Companion.getInstance(context)
+        boolean generalLocationOrTimeIssuesPresent = DataProvider.Companion.getInstance(context)
                 .flatMap(dataProvider -> dataProvider.observeEventByPlayaId("3y6Fs46vcvfYCVdmR8kU").toObservable())
                 .timeout(1, TimeUnit.SECONDS)
                 .map(event -> {
                     boolean hasWrongTime = event.startTimePretty.equals("Thu 8/31 12:30 PM");
                     boolean hasMissingLocation = !event.hasLocation();
                     return hasWrongTime || hasMissingLocation;
+                })
+                .onErrorReturnItem(false)
+                .blockingFirst();
+        if (generalLocationOrTimeIssuesPresent) {
+            return true;
+        }
+        // Paranormal hour event has a location set by a camp in a plaza, which was not
+        // geocoded properly due to presence of 'None None' string in playa address. This is
+        // representative of a large group of events.
+        return DataProvider.Companion.getInstance(context)
+                .flatMap(dataProvider -> dataProvider.observeEventByPlayaId("5np2awDjcSkko2YXgprV").toObservable())
+                .timeout(1, TimeUnit.SECONDS)
+                .map(event -> {
+                    boolean hasBadPlayaAddress = event.playaAddress.contains("None None");
+                    boolean hasMissingLocation = !event.hasLocation();
+                    return hasBadPlayaAddress || hasMissingLocation;
                 })
                 .onErrorReturnItem(false)
                 .blockingFirst();

--- a/iBurn/src/main/java/com/gaiagps/iburn/api/IBurnService.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/api/IBurnService.java
@@ -468,14 +468,15 @@ public class IBurnService {
             // Set and cache location for later use by events
 
             if (item.location != null) {
+                // https://github.com/iBurnApp/BlackRockCityPlanner/issues/6
+                if (!TextUtils.isEmpty(item.location.string)) {
+                    item.location.string = item.location.string.replace("None None", "");
+                }
 
                 Location location = new Location();
                 location.gps_latitude = item.location.gps_latitude;
                 location.gps_longitude = item.location.gps_longitude;
                 location.string = item.location.string;
-                // https://github.com/iBurnApp/BlackRockCityPlanner/issues/6
-                if (!TextUtils.isEmpty(location.string))
-                        location.string = location.string.replace("None None", "");
 
                 if (!TextUtils.isEmpty(location.string) &&
                         !(location.string.equals("Mobile")) &&

--- a/iBurn/src/main/java/com/gaiagps/iburn/api/IBurnService.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/api/IBurnService.java
@@ -1,10 +1,37 @@
 package com.gaiagps.iburn.api;
 
+import static com.gaiagps.iburn.SECRETSKt.IBURN_API_URL;
+import static com.gaiagps.iburn.database.Art.ARTIST;
+import static com.gaiagps.iburn.database.Art.ARTIST_LOCATION;
+import static com.gaiagps.iburn.database.Art.IMAGE_URL;
+import static com.gaiagps.iburn.database.Camp.HOMETOWN;
+import static com.gaiagps.iburn.database.Event.ALL_DAY;
+import static com.gaiagps.iburn.database.Event.CAMP_PLAYA_ID;
+import static com.gaiagps.iburn.database.Event.CHECK_LOC;
+import static com.gaiagps.iburn.database.Event.END_TIME;
+import static com.gaiagps.iburn.database.Event.END_TIME_PRETTY;
+import static com.gaiagps.iburn.database.Event.START_TIME;
+import static com.gaiagps.iburn.database.Event.START_TIME_PRETTY;
+import static com.gaiagps.iburn.database.Event.TYPE;
+import static com.gaiagps.iburn.database.PlayaItem.CONTACT;
+import static com.gaiagps.iburn.database.PlayaItem.DESC;
+import static com.gaiagps.iburn.database.PlayaItem.FAVORITE;
+import static com.gaiagps.iburn.database.PlayaItem.LATITUDE;
+import static com.gaiagps.iburn.database.PlayaItem.LATITUDE_UNOFFICIAL;
+import static com.gaiagps.iburn.database.PlayaItem.LONGITUDE;
+import static com.gaiagps.iburn.database.PlayaItem.LONGITUDE_UNOFFICIAL;
+import static com.gaiagps.iburn.database.PlayaItem.NAME;
+import static com.gaiagps.iburn.database.PlayaItem.PLAYA_ADDR;
+import static com.gaiagps.iburn.database.PlayaItem.PLAYA_ADDR_UNOFFICIAL;
+import static com.gaiagps.iburn.database.PlayaItem.PLAYA_ID;
+import static com.gaiagps.iburn.database.PlayaItem.URL;
+
 import android.content.ContentValues;
 import android.content.Context;
+import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.core.util.Pair;
-import android.text.TextUtils;
 
 import com.gaiagps.iburn.DateUtil;
 import com.gaiagps.iburn.PrefsHelper;
@@ -31,7 +58,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -47,32 +73,6 @@ import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.gson.GsonConverterFactory;
 import timber.log.Timber;
-
-import static com.gaiagps.iburn.SECRETSKt.IBURN_API_URL;
-import static com.gaiagps.iburn.database.Art.ARTIST;
-import static com.gaiagps.iburn.database.Art.ARTIST_LOCATION;
-import static com.gaiagps.iburn.database.Art.IMAGE_URL;
-import static com.gaiagps.iburn.database.Camp.HOMETOWN;
-import static com.gaiagps.iburn.database.Event.ALL_DAY;
-import static com.gaiagps.iburn.database.Event.CAMP_PLAYA_ID;
-import static com.gaiagps.iburn.database.Event.CHECK_LOC;
-import static com.gaiagps.iburn.database.Event.END_TIME;
-import static com.gaiagps.iburn.database.Event.END_TIME_PRETTY;
-import static com.gaiagps.iburn.database.Event.START_TIME;
-import static com.gaiagps.iburn.database.Event.START_TIME_PRETTY;
-import static com.gaiagps.iburn.database.Event.TYPE;
-import static com.gaiagps.iburn.database.PlayaItem.CONTACT;
-import static com.gaiagps.iburn.database.PlayaItem.DESC;
-import static com.gaiagps.iburn.database.PlayaItem.FAVORITE;
-import static com.gaiagps.iburn.database.PlayaItem.LATITUDE;
-import static com.gaiagps.iburn.database.PlayaItem.LATITUDE_UNOFFICIAL;
-import static com.gaiagps.iburn.database.PlayaItem.LONGITUDE;
-import static com.gaiagps.iburn.database.PlayaItem.LONGITUDE_UNOFFICIAL;
-import static com.gaiagps.iburn.database.PlayaItem.NAME;
-import static com.gaiagps.iburn.database.PlayaItem.PLAYA_ADDR;
-import static com.gaiagps.iburn.database.PlayaItem.PLAYA_ADDR_UNOFFICIAL;
-import static com.gaiagps.iburn.database.PlayaItem.PLAYA_ID;
-import static com.gaiagps.iburn.database.PlayaItem.URL;
 
 /**
  * A monolithic iBurn data updater. Handles fetching IBurn update data and update the database while
@@ -473,6 +473,9 @@ public class IBurnService {
                 location.gps_latitude = item.location.gps_latitude;
                 location.gps_longitude = item.location.gps_longitude;
                 location.string = item.location.string;
+                // https://github.com/iBurnApp/BlackRockCityPlanner/issues/6
+                if (!TextUtils.isEmpty(location.string))
+                        location.string = location.string.replace("None None", "");
 
                 if (!TextUtils.isEmpty(location.string) &&
                         !(location.string.equals("Mobile")) &&

--- a/iBurn/src/main/java/com/gaiagps/iburn/api/response/Location.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/api/response/Location.java
@@ -9,4 +9,12 @@ public class Location {
     public double gps_latitude;
     public double gps_longitude;
 
+    @Override
+    public String toString() {
+        return "Location{" +
+                "string='" + string + '\'' +
+                ", gps_latitude=" + gps_latitude +
+                ", gps_longitude=" + gps_longitude +
+                '}';
+    }
 }

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
@@ -453,7 +453,7 @@ class DataProvider private constructor(private val context: Context, private val
 
             // TODO : This ain't thread safe
 
-            if (provider != null) return Observable.just(provider!!)
+            if (provider != null) return Observable.just(provider!!).subscribeOn(Schedulers.io())
 
             val prefs = PrefsHelper(context)
 

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
@@ -40,6 +40,10 @@ class DataProvider private constructor(private val context: Context, private val
         upgradeLock.set(true)
     }
 
+    fun inUpgrade(): Boolean {
+        return upgradeLock.get();
+    }
+
     fun endUpgrade() {
         upgradeLock.set(false)
 
@@ -439,7 +443,7 @@ class DataProvider private constructor(private val context: Context, private val
         /**
          * Version of database data and mbtiles. This is basically the unix time at which bundled data was provided to this build.
          */
-        val RESOURCES_VERSION: Long = 1692384330152L // Unix time of creation
+        val RESOURCES_VERSION: Long = 1692570508202L // Unix time of creation
 
         private var provider: DataProvider? = null
 

--- a/iBurn/src/main/java/com/gaiagps/iburn/js/Geocoder.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/js/Geocoder.kt
@@ -58,14 +58,14 @@ object Geocoder {
                     init(context)
 
                     val result = LatLng()
-                    Timber.d("Forward geocoding '$playaAddress'...")
+//                    Timber.d("Forward geocoding '$playaAddress'...")
                     if (playaAddress.length < 8) {
                         Timber.w("Invalid playa address $playaAddress, not geocoding")
                     } else {
                         // Call into the JavaScript object to decode a string.
                         try {
                             val latLon = v8?.executeObjectScript("coder.forward(\"$playaAddress\")")
-                            Timber.d("Forward geocode result %s", latLon)
+//                            Timber.d("Forward geocode result %s", latLon)
 
                             latLon?.let {
                                 if (it.toString() == "undefined") {
@@ -79,7 +79,7 @@ object Geocoder {
                                         item = item.getArray(0)
                                     }
                                     val coords = item.getDoubles(0, 2)
-                                    Timber.d("Got coords! ${coords[0]}, ${coords[1]}")
+//                                    Timber.d("Got coords! ${coords[0]}, ${coords[1]}")
                                     result.latitude = coords[1]
                                     result.longitude = coords[0]
                                 }
@@ -90,6 +90,7 @@ object Geocoder {
                     }
                     result
                 }
+            .onErrorReturnItem(LatLng(0.0, 0.0))
     }
 
     private fun init(context: Context) {

--- a/iBurn/src/main/java/com/gaiagps/iburn/service/DataUpdateService.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/service/DataUpdateService.kt
@@ -8,6 +8,7 @@ import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.gaiagps.iburn.api.IBurnService
+import com.gaiagps.iburn.database.DataProvider
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 
@@ -39,6 +40,9 @@ class DataUpdateService(context: Context, workerParams: WorkerParameters) :
     }
 
     override fun doWork(): Result {
+        val dataProvider = DataProvider.getInstance(applicationContext).onErrorReturn { null }.blockingFirst()
+        if (dataProvider?.inUpgrade() == true) return Result.retry()
+
         val service = IBurnService(applicationContext)
         val success = service.updateData().blockingGet()
         Timber.d("Update task finished with success: $success")


### PR DESCRIPTION
The best part of doing yet another data reload was I realized we hadn't updated the v8 js runtime in a few years, it appears faster and more robust enough to be noticeable at my desk.

Tested on app with old and current database to ensure data reload works without losing user favorites or pois. 