### PR TITLE
Fix timer crash

### DIFF
--- a/iBurn/src/main/java/com/gaiagps/iburn/activity/MainActivity.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/activity/MainActivity.java
@@ -139,6 +139,8 @@ public class MainActivity extends AppCompatActivity implements SearchQueryProvid
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(tick -> {
                         showEmbargoBanner();
+                    }, throwable -> {
+                        Timber.e(throwable, "Error occurred while showing embargo banner");
                     });
         }
         handleIntent(getIntent());


### PR DESCRIPTION
Fixes this one: https://console.firebase.google.com/project/iburn-app/crashlytics/app/android:com.iburnapp.iburn3/issues/377f1bd2120133b217d8a8c406537657?time=last-seven-days&types=crash&sessionEventKey=66BB738700E3000118C87611144C2E57_1981083627928580102