### PR TITLE
guard mbtiles copy

### DIFF
--- a/iBurn/build.gradle
+++ b/iBurn/build.gradle
@@ -36,9 +36,9 @@ android {
         compileSdk 34
         minSdkVersion 23
         targetSdkVersion 34
-        versionCode 59
+        versionCode 61
 
-        versionName "$versionYear.3"
+        versionName "$versionYear.4"
 
         applicationId "com.iburnapp.iburn3"
 

--- a/iBurn/src/main/java/com/gaiagps/iburn/MapboxMapFragment.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/MapboxMapFragment.kt
@@ -70,7 +70,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.collections.set
 
 // Track MBTiles versions to avoid unnecessary copies from assets
-const val MBTILES_VERSION = 3L
+const val MBTILES_VERSION = 4L
 
 class MapboxMapFragment : Fragment() {
 

--- a/iBurn/src/main/java/com/gaiagps/iburn/MapboxMapFragment.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/MapboxMapFragment.kt
@@ -343,6 +343,7 @@ class MapboxMapFragment : Fragment() {
         return markerPlaceView
     }
 
+    @Synchronized
     private fun copyAssets(): String {
         val tilesInput = requireContext().assets.open("map/map.mbtiles")
         val tilesOutput = File(requireContext().getExternalFilesDir(null), "map.mbtiles")
@@ -351,14 +352,11 @@ class MapboxMapFragment : Fragment() {
             return tilesOutput.path
         }
         val tilesOutputStream = tilesOutput.outputStream()
-        val buffer = ByteArray(1024)
-        var read: Int
-        while (tilesInput.read(buffer).also { read = it } != -1) {
-            tilesOutputStream.write(buffer, 0, read)
+        tilesInput.use { input ->
+            tilesOutputStream.use { output ->
+                input.copyTo(output)
+            }
         }
-        tilesInput.close()
-        tilesOutputStream.flush()
-        tilesOutputStream.close()
         prefs.copiedMbtilesVersion = MBTILES_VERSION
         return tilesOutput.path
     }


### PR DESCRIPTION
To potentially address a `terminating with uncaught exception of type mapbox::sqlite::Exception: database disk image is malformed` error seen in production, ensure the "copy mbtiles" function cannot race.