### PR TITLE
Centralize event year configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,10 @@ Fortunately, you can still run and test the app with the previous year's data.
 
 #### Update code and text resources
 
-* Update `app_name` and `current_year` in iBurn/src/main/res/values/strings.xml
+* Update event year and dates in `EventInfo.kt`
 * Update `MOCK_NOW_DATE` in CurrentDateProvider (Used when simulating event time during testing)
 * Update `versionYear`, `versionName` and `versionCode` in `iBurn/build.gradle`
-* Update `EVENT_START_DATE` and `EVENT_END_DATE` in AdapterUtils.java
-* Update `EMBARGO_DATE` in Embargo.java
+* `versionYear` also populates the `app_name` and `current_year` string resources
 * Update `UNLOCK_CODE` in SECRETS.kt
 
 
@@ -72,9 +71,8 @@ The `./gradlew updateData` will copy art images and tour audio from the iBurn-Da
 
 ## Releasing
 Make sure you've:
-
-+ Set embargo date correctly in `Embargo.java`, and set `EVENT_START_DATE` and `EVENT_STOP_DATE` in `AdapterUtils`
-+ Incremented the version code and name in ./iBurn/build.grade
+* Set event dates correctly in `EventInfo.kt`
+* Incremented the version code and name in ./iBurn/build.grade
 The final pre-signed store release should be built with:
 
 ```

--- a/iBurn/build.gradle
+++ b/iBurn/build.gradle
@@ -42,6 +42,10 @@ android {
 
         applicationId "com.iburnapp.iburn3"
 
+        // Provide year-specific resources for use in XML
+        resValue "string", "app_name", "iBurn $versionYear"
+        resValue "string", "current_year", "$versionYear"
+
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         archivesBaseName = "iburn-$versionName-$versionCode"
 

--- a/iBurn/src/main/java/com/gaiagps/iburn/CurrentDateProvider.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/CurrentDateProvider.java
@@ -4,6 +4,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+import com.gaiagps.iburn.EventInfo;
+
 /**
  * Created by davidbrodsky on 7/8/15.
  */
@@ -13,7 +15,7 @@ public class CurrentDateProvider {
      * Date to use as "now" for Debug builds
      */
     private static Date MOCK_NOW_DATE = new GregorianCalendar(
-            2024, Calendar.AUGUST, 25, 10, 05)
+            EventInfo.CURRENT_YEAR, Calendar.AUGUST, 25, 10, 05)
             .getTime();
 
     public static Date getCurrentDate() {

--- a/iBurn/src/main/java/com/gaiagps/iburn/EventInfo.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/EventInfo.kt
@@ -1,0 +1,24 @@
+package com.gaiagps.iburn
+
+import java.util.Calendar
+import java.util.Date
+import java.util.GregorianCalendar
+
+object EventInfo {
+    const val CURRENT_YEAR = 2024
+
+    private fun createDate(year: Int, month: Int, day: Int): Date {
+        val cal = GregorianCalendar(year, month, day)
+        cal.timeZone = DateUtil.PLAYA_TIME_ZONE
+        return cal.time
+    }
+
+    @JvmField
+    val EVENT_START_DATE: Date = createDate(CURRENT_YEAR, Calendar.AUGUST, 25)
+
+    @JvmField
+    val EVENT_END_DATE: Date = createDate(CURRENT_YEAR, Calendar.SEPTEMBER, 2)
+
+    @JvmField
+    val EMBARGO_DATE: Date = createDate(CURRENT_YEAR, Calendar.AUGUST, 25)
+}

--- a/iBurn/src/main/java/com/gaiagps/iburn/adapters/AdapterUtils.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/adapters/AdapterUtils.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 
 import com.gaiagps.iburn.CurrentDateProvider;
 import com.gaiagps.iburn.DateUtil;
+import com.gaiagps.iburn.EventInfo;
 import com.gaiagps.iburn.Geo;
 import com.gaiagps.iburn.R;
 import com.gaiagps.iburn.api.typeadapter.PlayaDateTypeAdapter;
@@ -19,7 +20,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.Locale;
 
 /**
@@ -36,8 +36,8 @@ public class AdapterUtils {
     public static final SimpleDateFormat dayLabelFormatter = DateUtil.getPlayaTimeFormat("EE M/d");
     public static final SimpleDateFormat dayAbbrevFormatter = DateUtil.getPlayaTimeFormat("M/d");
 
-    public static final Date EVENT_START_DATE = createPlayaData(2024, Calendar.AUGUST, 25);
-    public static final Date EVENT_END_DATE = createPlayaData(2024, Calendar.SEPTEMBER, 2);
+    public static final Date EVENT_START_DATE = EventInfo.EVENT_START_DATE;
+    public static final Date EVENT_END_DATE = EventInfo.EVENT_END_DATE;
 
     public static final String EVENT_TYPE_ABBREVIATION_UNKNOWN = "unknwn";
     public static final String EVENT_TYPE_NAME_UNKNOWN = "Uncategorized";
@@ -86,12 +86,6 @@ public class AdapterUtils {
         // has all events categorized
 //        sEventTypeAbbreviations.add(EVENT_TYPE_ABBREVIATION_UNKNOWN);
 //        sEventTypeNames.add(EVENT_TYPE_NAME_UNKNOWN);
-    }
-
-    private static Date createPlayaData(int year, int month, int dayOfMonth) {
-        GregorianCalendar cal = new GregorianCalendar(year, month, dayOfMonth);
-        cal.setTimeZone(DateUtil.PLAYA_TIME_ZONE);
-        return cal.getTime();
     }
 
     private static void populateDayRanges(Date start, Date end) {

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/Embargo.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/Embargo.java
@@ -4,11 +4,10 @@ import androidx.annotation.NonNull;
 
 import com.gaiagps.iburn.BuildConfig;
 import com.gaiagps.iburn.CurrentDateProvider;
+import com.gaiagps.iburn.EventInfo;
 import com.gaiagps.iburn.PrefsHelper;
 
-import java.util.Calendar;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.Iterator;
 
 import static com.gaiagps.iburn.database.PlayaItem.LATITUDE;
@@ -23,8 +22,8 @@ import static com.gaiagps.iburn.database.PlayaItem.PLAYA_ADDR;
  */
 public class Embargo implements DataProvider.QueryInterceptor {
 
-    // 2024 Embargo date is August 25
-    public  static final Date   EMBARGO_DATE   = new GregorianCalendar(2024, Calendar.AUGUST, 25, 0, 0).getTime();
+    // Embargo date is the day gates open
+    public static final Date EMBARGO_DATE = EventInfo.EMBARGO_DATE;
 
     // For mock builds, force user to enter unlock code
     private static final boolean FORCE_EMBARGO = BuildConfig.MOCK;

--- a/iBurn/src/main/res/values/strings.xml
+++ b/iBurn/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">iBurn 2024</string>
+    <!-- Application name and year are provided by build.gradle -->
 
     <!-- MainActivity Tabs -->
     <string name="fav_tab">Faves️</string>
@@ -84,6 +84,6 @@
     <string name="pause_audio_tour">Pause Audio Tour</string>
     <string name="camp_location_unknown">Sorry, we don\'t have location data for that camp. You can add a marker later from the app\'s map view.</string>
     <string name="place_marker">Move the map, then tap marker to place it</string>
-    <string name="current_year">2024</string>
+    <!-- provided by build.gradle -->
 
 </resources>


### PR DESCRIPTION
## Summary
- introduce `EventInfo` object to hold the current year and event dates
- update code to use `EventInfo` constants
- generate `app_name` and `current_year` strings from Gradle
- adjust README annual update section

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b7db62f483228f5e2be3c43ca5f7