### PR TITLE
Unify event year constant

### DIFF
--- a/iBurn/build.gradle
+++ b/iBurn/build.gradle
@@ -27,12 +27,33 @@ ext {
     versionYear = 2024
 }
 
+// Generate a Kotlin file containing the current event year for use in code
+def generatedSrcDir = "${buildDir}/generated/source/eventyear"
+tasks.register('generateEventYear') {
+    outputs.dir generatedSrcDir
+    doLast {
+        def packageDir = new File(generatedSrcDir, 'com/gaiagps/iburn')
+        packageDir.mkdirs()
+        def outFile = new File(packageDir, 'EventYear.kt')
+        outFile.text = """
+package com.gaiagps.iburn
+
+object EventYear {
+    const val YEAR = ${versionYear}
+}
+""".trim()
+    }
+}
+
 kotlin {
     jvmToolchain(17)
 }
 
 
 android {
+    sourceSets {
+        main.java.srcDir(generatedSrcDir)
+    }
     buildFeatures {
         buildConfig = true
         viewBinding = true
@@ -291,4 +312,9 @@ task updateData {
             into "$projectDir/src/main/assets/json/"
         }
     }
+}
+
+// Ensure generated source is available before compiling
+tasks.named('preBuild') {
+    dependsOn(generateEventYear)
 }

--- a/iBurn/src/main/java/com/gaiagps/iburn/EventInfo.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/EventInfo.kt
@@ -4,8 +4,10 @@ import java.util.Calendar
 import java.util.Date
 import java.util.GregorianCalendar
 
+import com.gaiagps.iburn.EventYear
+
 object EventInfo {
-    const val CURRENT_YEAR = 2024
+    const val CURRENT_YEAR = EventYear.YEAR
 
     private fun createDate(year: Int, month: Int, day: Int): Date {
         val cal = GregorianCalendar(year, month, day)


### PR DESCRIPTION
## Summary
- generate an `EventYear` class from Gradle
- reference `EventYear.YEAR` inside `EventInfo`
- hook generation task into the build

## Testing
- `./gradlew :iBurn:generateEventYear --dry-run`
- `./gradlew :iBurn:generateEventYear`

------
https://chatgpt.com/codex/tasks/task_e_6869d72afc6c8322a00979b79a187078