### PR TITLE
Fix detail view lookup by DB id

### DIFF
--- a/iBurn/src/main/java/com/gaiagps/iburn/IntentUtil.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/IntentUtil.java
@@ -21,8 +21,8 @@ public class IntentUtil {
 
     public static void viewItemDetail(@NonNull Activity host, PlayaItem item) {
         Intent i = new Intent(host, PlayaItemViewActivity.class);
-        String playaId = item.playaId;
-        i.putExtra(PlayaItemViewActivity.EXTRA_PLAYA_ITEM_ID, playaId);
+        int id = item.id;
+        i.putExtra(PlayaItemViewActivity.EXTRA_PLAYA_ITEM_ID, id);
         if (item instanceof Camp) {
             i.putExtra(PlayaItemViewActivity.EXTRA_PLAYA_ITEM_TYPE, EXTRA_PLAYA_ITEM_CAMP);
         } else if (item instanceof Art) {

--- a/iBurn/src/main/java/com/gaiagps/iburn/activity/PlayaItemViewActivity.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/activity/PlayaItemViewActivity.java
@@ -83,7 +83,8 @@ import org.maplibre.android.geometry.LatLng;
  */
 public class PlayaItemViewActivity extends AppCompatActivity implements AdapterListener {
 
-    public static final String EXTRA_PLAYA_ITEM_ID = "playa-id";
+    // Database primary key for the item to display
+    public static final String EXTRA_PLAYA_ITEM_ID = "playa-item-id";
     public static final String EXTRA_PLAYA_ITEM_TYPE = "playa-type";
     public static final String EXTRA_PLAYA_ITEM_CAMP = "playa-camp";
     public static final String EXTRA_PLAYA_ITEM_ART = "playa-art";
@@ -140,31 +141,31 @@ public class PlayaItemViewActivity extends AppCompatActivity implements AdapterL
     }
 
     private void loadPlayaItemFromIntent(Intent i) {
-        String playaId = i.getStringExtra(EXTRA_PLAYA_ITEM_ID);
+        int itemId = i.getIntExtra(EXTRA_PLAYA_ITEM_ID, -1);
         String type = i.getStringExtra(EXTRA_PLAYA_ITEM_TYPE);
-        if (playaId == null || type == null) {
-            throw new IllegalArgumentException("Missing playaId or type in Intent");
+        if (itemId == -1 || type == null) {
+            throw new IllegalArgumentException("Missing itemId or type in Intent");
         }
         // Use DataProvider to fetch the item
         DataProvider.Companion.getInstance(getApplicationContext())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(dataProvider -> {
                 if (EXTRA_PLAYA_ITEM_CAMP.equals(type)) {
-                    playaItemDisposable = dataProvider.observeCampByPlayaId(playaId)
+                    playaItemDisposable = dataProvider.observeCampById(itemId)
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(item -> {
                             itemWithUserData = item;
                             onPlayaItemLoaded();
                         }, throwable -> finishWithError(throwable));
                 } else if (EXTRA_PLAYA_ITEM_ART.equals(type)) {
-                    playaItemDisposable = dataProvider.observeArtByPlayaId(playaId)
+                    playaItemDisposable = dataProvider.observeArtById(itemId)
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(item -> {
                             itemWithUserData = item;
                             onPlayaItemLoaded();
                         }, throwable -> finishWithError(throwable));
                 } else if (EXTRA_PLAYA_ITEM_EVENT.equals(type)) {
-                    playaItemDisposable = dataProvider.observeEventByPlayaId(playaId)
+                    playaItemDisposable = dataProvider.observeEventById(itemId)
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(item -> {
                             itemWithUserData = item;

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/ArtDao.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/ArtDao.kt
@@ -82,4 +82,13 @@ interface ArtDao {
             " WHERE a." + PlayaItem.PLAYA_ID + " = :playaId"
     )
     fun findByPlayaId(playaId: String): Flowable<ArtWithUserData>
+
+    @Query(
+        "SELECT a.*, CASE WHEN f." + Favorite.PLAYA_ID +
+            " IS NOT NULL THEN 1 ELSE 0 END AS " + UserData.FAVORITE +
+            " FROM " + Art.TABLE_NAME + " a LEFT JOIN " + Favorite.TABLE_NAME +
+            " f ON a." + PlayaItem.PLAYA_ID + " = f." + Favorite.PLAYA_ID +
+            " WHERE a." + PlayaItem.ID + " = :id"
+    )
+    fun findById(id: Int): Flowable<ArtWithUserData>
 }

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/CampDao.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/CampDao.kt
@@ -51,6 +51,15 @@ interface CampDao {
             " IS NOT NULL THEN 1 ELSE 0 END AS " + UserData.FAVORITE +
             " FROM " + Camp.TABLE_NAME + " c LEFT JOIN " + Favorite.TABLE_NAME +
             " f ON c." + PlayaItem.PLAYA_ID + " = f." + Favorite.PLAYA_ID +
+            " WHERE c." + PlayaItem.ID + " = :id"
+    )
+    fun findById(id: Int): Flowable<CampWithUserData>
+
+    @Query(
+        "SELECT c.*, CASE WHEN f." + Favorite.PLAYA_ID +
+            " IS NOT NULL THEN 1 ELSE 0 END AS " + UserData.FAVORITE +
+            " FROM " + Camp.TABLE_NAME + " c LEFT JOIN " + Favorite.TABLE_NAME +
+            " f ON c." + PlayaItem.PLAYA_ID + " = f." + Favorite.PLAYA_ID +
             " WHERE (c." + PlayaItem.LATITUDE + " BETWEEN :minLat AND :maxLat) " +
             "AND (c." + PlayaItem.LONGITUDE + " BETWEEN :minLon AND :maxLon)"
     )

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
@@ -89,6 +89,10 @@ class DataProvider private constructor(private val context: Context, private val
         return db.campDao().findByPlayaId(playaId)
     }
 
+    fun observeCampById(id: Int): Flowable<CampWithUserData> {
+        return db.campDao().findById(id)
+    }
+
     fun beginTransaction() {
         db.beginTransaction()
         //        BriteDatabase.Transaction t = db.newTransaction();
@@ -136,6 +140,10 @@ class DataProvider private constructor(private val context: Context, private val
 
     fun observeEventByPlayaId(id: String): Single<EventWithUserData> {
         return db.eventDao().getByPlayaId(id)
+    }
+
+    fun observeEventById(id: Int): Single<EventWithUserData> {
+        return db.eventDao().getById(id)
     }
 
     fun observeEventsOnDayOfTypes(day: String,
@@ -239,6 +247,10 @@ class DataProvider private constructor(private val context: Context, private val
 
     fun observeArtByPlayaId(playaId: String): Flowable<ArtWithUserData> {
         return db.artDao().findByPlayaId(playaId)
+    }
+
+    fun observeArtById(id: Int): Flowable<ArtWithUserData> {
+        return db.artDao().findById(id)
     }
 
     /**

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/EventDao.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/EventDao.kt
@@ -31,6 +31,16 @@ interface EventDao {
     )
     fun getByPlayaId(id: String?): Single<EventWithUserData>
 
+    @Query(
+        "SELECT e.*, CASE WHEN f." + Favorite.PLAYA_ID +
+            " IS NOT NULL THEN 1 ELSE 0 END AS " + UserData.FAVORITE +
+            " FROM " + Event.TABLE_NAME + " e LEFT JOIN " + Favorite.TABLE_NAME +
+            " f ON e." + PlayaItem.PLAYA_ID + " = f." + Favorite.PLAYA_ID +
+            " AND e." + Event.START_TIME + " = f." + Favorite.START_TIME +
+            " WHERE e." + PlayaItem.ID + " = :id"
+    )
+    fun getById(id: Int): Single<EventWithUserData>
+
     @get:Query(
         "SELECT e.*, 1 AS " + UserData.FAVORITE +
             " FROM " + Event.TABLE_NAME + " e INNER JOIN " + Favorite.TABLE_NAME +


### PR DESCRIPTION
## Summary
- pass the database primary key instead of playaId when opening detail views
- fetch Camps, Art, and Events by DB id

## Testing
- `./gradlew assembleDebug` *(fails: android.useAndroidX not enabled)*

------
https://chatgpt.com/codex/tasks/task_e_686c78cbffb88322b6c7d6a51908f2a2