### PR TITLE
Enable FTS based search

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -33,8 +33,7 @@ The content fragments are all self-contained and independent of `MainActivity`.
 
 There's currently a persistent search Floating Action Button (yuck!) that
 directs the user to [`SearchActivity`](https://github.com/Burning-Man-Earth/iBurn-Android/blob/8cb6414628959b16531f108778781e7a8c51795b/iBurn/src/main/java/com/gaiagps/iburn/activity/SearchActivity.java).
-Search is currently based on a name column query via [`DataProvider.observeNameQuery()`](https://github.com/Burning-Man-Earth/iBurn-Android/blob/5f99b17e70c3080dc0780c74d7e7dc5933865293/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.java#L305-L305),
-but we should change to also incorporate descriptions.
+Search is performed using SQLite full text search via [`DataProvider.observeFtsQuery()`](https://github.com/Burning-Man-Earth/iBurn-Android/blob/5f99b17e70c3080dc0780c74d7e7dc5933865293/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.java#L305-L305).
 
 [`PlayaItemViewActivity`](https://github.com/Burning-Man-Earth/iBurn-Android/blob/44b30e369ef438df9899280c78688cbaed2a5d20/iBurn/src/main/java/com/gaiagps/iburn/activity/PlayaItemViewActivity.java) is used as a "detail view" of a Camp, Art, or Event
 anywhere that's necessary in the app. It's also probably the most embarrassing piece of shit in the app because it

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/ArtDao.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/ArtDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
+import androidx.room.SkipQueryVerification
 import io.reactivex.Flowable
 
 /**
@@ -34,6 +35,16 @@ interface ArtDao {
             " WHERE a." + PlayaItem.NAME + " LIKE :name"
     )
     fun findByName(name: String?): Flowable<List<ArtWithUserData>>
+
+    @SkipQueryVerification
+    @Query(
+        "SELECT a.*, CASE WHEN f." + Favorite.PLAYA_ID +
+            " IS NOT NULL THEN 1 ELSE 0 END AS " + UserData.FAVORITE +
+            " FROM " + Art.TABLE_NAME + " a LEFT JOIN " + Favorite.TABLE_NAME +
+            " f ON a." + PlayaItem.PLAYA_ID + " = f." + Favorite.PLAYA_ID +
+            " WHERE a." + PlayaItem.ID + " IN (SELECT rowid FROM arts_fts WHERE arts_fts MATCH :query)"
+    )
+    fun searchFts(query: String?): Flowable<List<ArtWithUserData>>
 
     @Query(
         "SELECT a.*, CASE WHEN f." + Favorite.PLAYA_ID +

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/CampDao.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/CampDao.kt
@@ -1,10 +1,10 @@
 package com.gaiagps.iburn.database
 
 import androidx.room.Dao
-import androidx.room.Fts4
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
+import androidx.room.SkipQueryVerification
 import io.reactivex.Flowable
 
 /**
@@ -36,6 +36,16 @@ interface CampDao {
             " WHERE c." + PlayaItem.NAME + " LIKE :name"
     )
     fun findByName(name: String?): Flowable<List<CampWithUserData>>
+
+    @SkipQueryVerification
+    @Query(
+        "SELECT c.*, CASE WHEN f." + Favorite.PLAYA_ID +
+            " IS NOT NULL THEN 1 ELSE 0 END AS " + UserData.FAVORITE +
+            " FROM " + Camp.TABLE_NAME + " c LEFT JOIN " + Favorite.TABLE_NAME +
+            " f ON c." + PlayaItem.PLAYA_ID + " = f." + Favorite.PLAYA_ID +
+            " WHERE c." + PlayaItem.ID + " IN (SELECT rowid FROM camps_fts WHERE camps_fts MATCH :query)"
+    )
+    fun searchFts(query: String?): Flowable<List<CampWithUserData>>
 
     @Query(
         "SELECT c.*, CASE WHEN f." + Favorite.PLAYA_ID +

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
@@ -301,21 +301,20 @@ class DataProvider private constructor(private val context: Context, private val
     }
 
     /**
-     * Observe all results for a name query.
-     *
+     * Observe all results for a full text search query.
      *
      * Note: This query automatically adds in Event.startTime (and 0 values for all non-events),
      * since we always want to show this data for an event.
      */
-    fun observeNameQuery(query: String): Flowable<SectionedPlayaItems> {
+    fun observeFtsQuery(query: String): Flowable<SectionedPlayaItems> {
 
         // TODO : Honor upgradeLock
         // TODO : Return structure with metadata on how many art, camps, events etc?
         val wildQuery = addWildcardsToQuery(query)
         return Flowables.combineLatest(
-                db.artDao().findByName(wildQuery),
-                db.campDao().findByName(wildQuery),
-                db.eventDao().findByName(wildQuery),
+                db.artDao().searchFts(query),
+                db.campDao().searchFts(query),
+                db.eventDao().searchFts(query),
                 db.userPoiDao().findByName(wildQuery))
         { arts, camps, events, userpois ->
             val sections = ArrayList<IntRange>(4)

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/EventDao.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/EventDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
+import androidx.room.SkipQueryVerification
 import io.reactivex.Flowable
 import io.reactivex.Single
 
@@ -68,6 +69,17 @@ interface EventDao {
             " WHERE e." + PlayaItem.NAME + " LIKE :name OR e." + PlayaItem.DESC + " LIKE :name GROUP BY e." + PlayaItem.NAME
     )
     fun findByName(name: String?): Flowable<List<EventWithUserData>>
+
+    @SkipQueryVerification
+    @Query(
+        "SELECT e.*, CASE WHEN f." + Favorite.PLAYA_ID +
+            " IS NOT NULL THEN 1 ELSE 0 END AS " + UserData.FAVORITE +
+            " FROM " + Event.TABLE_NAME + " e LEFT JOIN " + Favorite.TABLE_NAME +
+            " f ON e." + PlayaItem.PLAYA_ID + " = f." + Favorite.PLAYA_ID +
+            " AND e." + Event.START_TIME + " = f." + Favorite.START_TIME +
+            " WHERE e." + PlayaItem.ID + " IN (SELECT rowid FROM events_fts WHERE events_fts MATCH :query)"
+    )
+    fun searchFts(query: String?): Flowable<List<EventWithUserData>>
 
 
     @Query(

--- a/iBurn/src/main/java/com/gaiagps/iburn/fragment/SearchFragment.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/fragment/SearchFragment.java
@@ -96,7 +96,7 @@ public class SearchFragment extends Fragment implements AdapterListener {
             searchSubscription.dispose();
 
         searchSubscription = DataProvider.Companion.getInstance(getContext().getApplicationContext())
-                .flatMap(dataProvider -> dataProvider.observeNameQuery(query).toObservable()) // TODO : rm toObservable
+                .flatMap(dataProvider -> dataProvider.observeFtsQuery(query).toObservable()) // TODO : rm toObservable
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(sectionedPlayaItems -> {
                     binding.resultsSummary.setText(describeResults(sectionedPlayaItems));


### PR DESCRIPTION
## Summary
- implement SQLite FTS search helper `observeFtsQuery`
- add FTS search queries for art, camps and events
- update search UI and docs

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686caeb5d0b88322abb206f2b5083573