### PR TITLE
Enable FTS based search

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -33,8 +33,7 @@ The content fragments are all self-contained and independent of `MainActivity`.
 
 There's currently a persistent search Floating Action Button (yuck!) that
 directs the user to [`SearchActivity`](https://github.com/Burning-Man-Earth/iBurn-Android/blob/8cb6414628959b16531f108778781e7a8c51795b/iBurn/src/main/java/com/gaiagps/iburn/activity/SearchActivity.java).
-Search is currently based on a name column query via [`DataProvider.observeNameQuery()`](https://github.com/Burning-Man-Earth/iBurn-Android/blob/5f99b17e70c3080dc0780c74d7e7dc5933865293/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.java#L305-L305),
-but we should change to also incorporate descriptions.
+Search is performed using SQLite full text search via [`DataProvider.observeFtsQuery()`](https://github.com/Burning-Man-Earth/iBurn-Android/blob/5f99b17e70c3080dc0780c74d7e7dc5933865293/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.java#L305-L305).
 
 [`PlayaItemViewActivity`](https://github.com/Burning-Man-Earth/iBurn-Android/blob/44b30e369ef438df9899280c78688cbaed2a5d20/iBurn/src/main/java/com/gaiagps/iburn/activity/PlayaItemViewActivity.java) is used as a "detail view" of a Camp, Art, or Event
 anywhere that's necessary in the app. It's also probably the most embarrassing piece of shit in the app because it

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/ArtDao.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/ArtDao.kt
@@ -40,6 +40,17 @@ interface ArtDao {
             " IS NOT NULL THEN 1 ELSE 0 END AS " + UserData.FAVORITE +
             " FROM " + Art.TABLE_NAME + " a LEFT JOIN " + Favorite.TABLE_NAME +
             " f ON a." + PlayaItem.PLAYA_ID + " = f." + Favorite.PLAYA_ID +
+            " JOIN " + ArtFts.TABLE_NAME +
+            " ON a." + PlayaItem.ID + " = " + ArtFts.TABLE_NAME + ".rowid" +
+            " WHERE " + ArtFts.TABLE_NAME + " MATCH :query"
+    )
+    fun searchFts(query: String?): Flowable<List<ArtWithUserData>>
+
+    @Query(
+        "SELECT a.*, CASE WHEN f." + Favorite.PLAYA_ID +
+            " IS NOT NULL THEN 1 ELSE 0 END AS " + UserData.FAVORITE +
+            " FROM " + Art.TABLE_NAME + " a LEFT JOIN " + Favorite.TABLE_NAME +
+            " f ON a." + PlayaItem.PLAYA_ID + " = f." + Favorite.PLAYA_ID +
             " WHERE (a." + PlayaItem.LATITUDE + " BETWEEN :minLat AND :maxLat) " +
             "AND (a." + PlayaItem.LONGITUDE + " BETWEEN :minLon AND :maxLon)"
     )

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/ArtFts.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/ArtFts.kt
@@ -1,0 +1,16 @@
+package com.gaiagps.iburn.database
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Fts4
+
+@Fts4(contentEntity = Art::class)
+@Entity(tableName = ArtFts.TABLE_NAME)
+data class ArtFts(
+    @ColumnInfo(name = PlayaItem.NAME) val name: String?,
+    @ColumnInfo(name = PlayaItem.DESC) val description: String?,
+    @ColumnInfo(name = Art.ARTIST) val artist: String?,
+    @ColumnInfo(name = Art.ARTIST_LOCATION) val artistLocation: String?
+) {
+    companion object { const val TABLE_NAME = "arts_fts" }
+}

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/CampDao.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/CampDao.kt
@@ -1,7 +1,6 @@
 package com.gaiagps.iburn.database
 
 import androidx.room.Dao
-import androidx.room.Fts4
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
@@ -36,6 +35,17 @@ interface CampDao {
             " WHERE c." + PlayaItem.NAME + " LIKE :name"
     )
     fun findByName(name: String?): Flowable<List<CampWithUserData>>
+
+    @Query(
+        "SELECT c.*, CASE WHEN f." + Favorite.PLAYA_ID +
+            " IS NOT NULL THEN 1 ELSE 0 END AS " + UserData.FAVORITE +
+            " FROM " + Camp.TABLE_NAME + " c LEFT JOIN " + Favorite.TABLE_NAME +
+            " f ON c." + PlayaItem.PLAYA_ID + " = f." + Favorite.PLAYA_ID +
+            " JOIN " + CampFts.TABLE_NAME +
+            " ON c." + PlayaItem.ID + " = " + CampFts.TABLE_NAME + ".rowid" +
+            " WHERE " + CampFts.TABLE_NAME + " MATCH :query"
+    )
+    fun searchFts(query: String?): Flowable<List<CampWithUserData>>
 
     @Query(
         "SELECT c.*, CASE WHEN f." + Favorite.PLAYA_ID +

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/CampFts.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/CampFts.kt
@@ -1,0 +1,15 @@
+package com.gaiagps.iburn.database
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Fts4
+
+@Fts4(contentEntity = Camp::class)
+@Entity(tableName = CampFts.TABLE_NAME)
+data class CampFts(
+    @ColumnInfo(name = PlayaItem.NAME) val name: String?,
+    @ColumnInfo(name = PlayaItem.DESC) val description: String?,
+    @ColumnInfo(name = Camp.HOMETOWN) val hometown: String?
+) {
+    companion object { const val TABLE_NAME = "camps_fts" }
+}

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/DataProvider.kt
@@ -301,21 +301,20 @@ class DataProvider private constructor(private val context: Context, private val
     }
 
     /**
-     * Observe all results for a name query.
-     *
+     * Observe all results for a full text search query.
      *
      * Note: This query automatically adds in Event.startTime (and 0 values for all non-events),
      * since we always want to show this data for an event.
      */
-    fun observeNameQuery(query: String): Flowable<SectionedPlayaItems> {
+    fun observeFtsQuery(query: String): Flowable<SectionedPlayaItems> {
 
         // TODO : Honor upgradeLock
         // TODO : Return structure with metadata on how many art, camps, events etc?
         val wildQuery = addWildcardsToQuery(query)
         return Flowables.combineLatest(
-                db.artDao().findByName(wildQuery),
-                db.campDao().findByName(wildQuery),
-                db.eventDao().findByName(wildQuery),
+                db.artDao().searchFts(query),
+                db.campDao().searchFts(query),
+                db.eventDao().searchFts(query),
                 db.userPoiDao().findByName(wildQuery))
         { arts, camps, events, userpois ->
             val sections = ArrayList<IntRange>(4)

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/EventDao.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/EventDao.kt
@@ -69,6 +69,18 @@ interface EventDao {
     )
     fun findByName(name: String?): Flowable<List<EventWithUserData>>
 
+    @Query(
+        "SELECT e.*, CASE WHEN f." + Favorite.PLAYA_ID +
+            " IS NOT NULL THEN 1 ELSE 0 END AS " + UserData.FAVORITE +
+            " FROM " + Event.TABLE_NAME + " e LEFT JOIN " + Favorite.TABLE_NAME +
+            " f ON e." + PlayaItem.PLAYA_ID + " = f." + Favorite.PLAYA_ID +
+            " AND e." + Event.START_TIME + " = f." + Favorite.START_TIME +
+            " JOIN " + EventFts.TABLE_NAME +
+            " ON e." + PlayaItem.ID + " = " + EventFts.TABLE_NAME + ".rowid" +
+            " WHERE " + EventFts.TABLE_NAME + " MATCH :query"
+    )
+    fun searchFts(query: String?): Flowable<List<EventWithUserData>>
+
 
     @Query(
         "SELECT e.*, CASE WHEN f." + Favorite.PLAYA_ID +

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/EventFts.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/EventFts.kt
@@ -1,0 +1,14 @@
+package com.gaiagps.iburn.database
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Fts4
+
+@Fts4(contentEntity = Event::class)
+@Entity(tableName = EventFts.TABLE_NAME)
+data class EventFts(
+    @ColumnInfo(name = PlayaItem.NAME) val name: String?,
+    @ColumnInfo(name = PlayaItem.DESC) val description: String?
+) {
+    companion object { const val TABLE_NAME = "events_fts" }
+}

--- a/iBurn/src/main/java/com/gaiagps/iburn/database/PlayaDatabase2.kt
+++ b/iBurn/src/main/java/com/gaiagps/iburn/database/PlayaDatabase2.kt
@@ -29,6 +29,9 @@ private const val DATABASE_V1 = 1
         Art::class,
         Camp::class,
         Event::class,
+        ArtFts::class,
+        CampFts::class,
+        EventFts::class,
         UserPoi::class,
         Favorite::class
     ),

--- a/iBurn/src/main/java/com/gaiagps/iburn/fragment/SearchFragment.java
+++ b/iBurn/src/main/java/com/gaiagps/iburn/fragment/SearchFragment.java
@@ -96,7 +96,7 @@ public class SearchFragment extends Fragment implements AdapterListener {
             searchSubscription.dispose();
 
         searchSubscription = DataProvider.Companion.getInstance(getContext().getApplicationContext())
-                .flatMap(dataProvider -> dataProvider.observeNameQuery(query).toObservable()) // TODO : rm toObservable
+                .flatMap(dataProvider -> dataProvider.observeFtsQuery(query).toObservable()) // TODO : rm toObservable
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(sectionedPlayaItems -> {
                     binding.resultsSummary.setText(describeResults(sectionedPlayaItems));


### PR DESCRIPTION
## Summary
- implement SQLite FTS search helper `observeFtsQuery`
- add FTS search queries for art, camps and events
- update search UI and docs
- declare FTS tables with `@Fts4` instead of using `@SkipQueryVerification`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686caeb5d0b88322abb206f2b5083573